### PR TITLE
Update conductor.py

### DIFF
--- a/client/python/conductor/conductor.py
+++ b/client/python/conductor/conductor.py
@@ -47,8 +47,7 @@ class BaseClient(object):
         if headers is not None:
             theHeader = self.mergeTwoDicts(self.headers, headers)
         if body is not None:
-            jsonBody = json.dumps(body, ensure_ascii=False)
-            resp = requests.post(theUrl, params=queryParams, data=jsonBody, headers=theHeader)
+            resp = requests.post(theUrl, params=queryParams, data=body, headers=theHeader)
         else:
             resp = requests.post(theUrl, params=queryParams, headers=theHeader)
 
@@ -62,8 +61,7 @@ class BaseClient(object):
             theHeader = self.mergeTwoDicts(self.headers, headers)
 
         if body is not None:
-            jsonBody = json.dumps(body, ensure_ascii=False)
-            resp = requests.put(theUrl, params=queryParams, data=jsonBody, headers=theHeader)
+            resp = requests.put(theUrl, params=queryParams, data=body, headers=theHeader)
         else:
             resp = requests.put(theUrl, params=queryParams, headers=theHeader)
 


### PR DESCRIPTION
The json.dumps before the requests.post/put causes an error when the parameter body comes from the method registerTaskDef, making it impossible to use.
Method registerTaskDef expects a string while post/put expect an input (list of dictionaries) that will be turned into a string, this inconsistency causes an error when trying to use registerTaskDef, with no workaround.
